### PR TITLE
set_alarm enhancement

### DIFF
--- a/rv3028.py
+++ b/rv3028.py
@@ -6,7 +6,6 @@ Authors: Nicole Maggard, Michael Pham, and Rachel Sarmiento
 
 import adafruit_bus_device.i2c_device as i2c_device
 
-
 class RV3028:
     # Register addresses
     SECONDS = 0x00
@@ -103,11 +102,11 @@ class RV3028:
         control2 |= 0x08  # Set AIE (Alarm Interrupt Enable) bit
         self._write_register(self.CONTROL2, bytes([control2]))
 
-        if minute is not None and minute < 0 or minute > 59:
+        if minute is not None and (minute < 0 or minute > 59):
             raise ValueError("Invalid minute value")
-        if hour is not None and hour < 0 or hour > 23:
+        if hour is not None and (hour < 0 or hour > 23):
             raise ValueError("Invalid hour value")
-        if weekday is not None and weekday < 0 or weekday > 6:
+        if weekday is not None and (weekday < 0 or weekday > 6):
             raise ValueError("Invalid weekday value")
 
         data = bytes(

--- a/rv3028.py
+++ b/rv3028.py
@@ -116,6 +116,28 @@ class RV3028:
 
         self._write_register(self.ALARM_MINUTES, data)
 
+    def check_alarm(self, clear = True):
+        """
+        Check if the alarm flag has been triggered.
+
+        :param clear: (Default: True) True to clear the alarm flag, False to leave it set
+        :return: True if alarm flag is set, False otherwise
+        """
+        status = self._read_register(self.STATUS)[0]
+        result = bool(status & 0x04)  # Check AF (bit 3)
+        if clear and result:
+            self._clear_alarm_flag()
+
+        return result
+
+    def _clear_alarm_flag(self):
+        """
+        Clear the alarm flag.
+        """
+        status = self._read_register(self.STATUS)[0]
+        status &= ~0x04  # clear AF bit
+        self._write_register(self.STATUS, bytes(status))
+
     def enable_trickle_charger(self, resistance=3000):
         control1 = self._read_register(self.CONTROL1)[0]
         control1 |= 0x20  # Set TCE (Trickle Charge Enable) bit


### PR DESCRIPTION
This PR does the following:
1. Add optional kwargs to the `set_alarm` function to determine if minutes, hours, and weekdays should be ignored. If not provided, the driver will set the disable flag to 1 (disabling that alarm component). 
2. Adds validation for the input, raising a ValueError if the argument values fall out of expected bounds.
3. Resolves #1 by using the ALARM_MINUTES register instead of the MINUTES register. 